### PR TITLE
Extract keys from file when no option is given

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ In addition:
 - Password requires
   -   The password (use the -p arg to supply the password)
 
+If you provide no other option than the logfile, it is expected to contain the VMK in clear, meaning it has been generated with a disk where protection was temporary disabled, and dislocker could find a clear key.  
+
 > [!NOTE]
 > Please note the sniffed data from the TPM is handled differently depending on the mode  
 > If bitlocker is in TPM or TPMandKEY the data you sniff is a key and use -k $key  


### PR DESCRIPTION
There are some cases where bitlocker 'unprotects' the disk, and temporarily stores a record with keys in clear, to be able to reboot without asking passsword.  In this case you can use dislocker without any key, and it will access the drive and generate the log file.

This PR takes this case into account, extracting the VMK from the log file, and writing recovery and fvek files, when only the log file has been given in argument.

To add this unprotected key to an existing disk, as an administrator you can use `manage-bde -protectors -disable C:`, and then in the output of `manage-bde -status` you will see `Protection Status: Protection Off (1 reboots left)`